### PR TITLE
Fix calculation of shift amount for vector single-width shift instructions

### DIFF
--- a/src/vpu/softvector-element.cpp
+++ b/src/vpu/softvector-element.cpp
@@ -57,6 +57,7 @@ inline SVElement u_mul_u(const SVElement& target, const SVElement& op1, const SV
 inline size_t get_shiftamount(size_t target_width_bits, const uint8_t* rhs) {
 	size_t numberofbits = 0;
 	size_t shiftamount = 0;
+	target_width_bits >>= 1;
 	while(target_width_bits) {
 		target_width_bits = target_width_bits >> 1;
 		shiftamount |= rhs[numberofbits/8] & (1 << numberofbits);
@@ -68,6 +69,7 @@ inline size_t get_shiftamount(size_t target_width_bits, const uint8_t* rhs) {
 inline size_t get_shiftamount(size_t target_width_bits, uint64_t rhs) {
 	size_t numberofbits = 0;
 	size_t shiftamount = 0;
+	target_width_bits >>= 1;
 	while(target_width_bits) {
 		target_width_bits = target_width_bits >> 1;
 		shiftamount |= rhs & (1 << numberofbits);


### PR DESCRIPTION
### Description

According to the current [RISC-V ISA manual](https://github.com/riscv/riscv-isa-manual/releases/tag/riscv-isa-release-cb6a524-2024-07-30), only the lower $log_2(SEW)$ bits of the shift amount are used to determine the actual shift amount for single-width `vsll, vsrl,` and `vsra`. Currently, due to an extra loop iteration, one extra bit is included. This PR addresses this issue by simply shifting `target_width_bits` right by one before the loop.